### PR TITLE
🔧 Fix GitHub Actions workflow to generate Wails bindings

### DIFF
--- a/.github/workflows/update-readme-coverage.yml
+++ b/.github/workflows/update-readme-coverage.yml
@@ -40,8 +40,14 @@ jobs:
         go mod download
         cd frontend && npm ci
 
+    - name: Install Wails CLI
+      run: go install github.com/wailsapp/wails/v2/cmd/wails@latest
+
     - name: Create fake frontend dist for go:embed
       run: mkdir -p frontend/dist && echo '{}' > frontend/dist/index.html
+
+    - name: Generate Wails bindings
+      run: wails generate module
 
     - name: Run backend tests with coverage
       run: make test-coverage


### PR DESCRIPTION
## Summary
- Fix frontend test failures in update-readme-coverage workflow by adding missing Wails CLI installation and binding generation steps
- Add `wails generate module` step before running frontend tests
- Ensure apiUtils.js and syncUtils.js can properly import Wails functions during CI

## Test plan
- [x] Verify workflow file changes are syntactically correct
- [ ] Confirm GitHub Actions runs successfully after merge
- [ ] Validate frontend tests pass with generated Wails bindings
- [ ] Check coverage badge updates work properly

## Changes Made
1. **Install Wails CLI**: Added step to install `wails` command in CI environment
2. **Generate Wails bindings**: Added `wails generate module` step before frontend tests
3. **Proper sequencing**: Ensured bindings are generated after dependencies but before tests

## Root Cause
The update-readme-coverage workflow was missing the Wails binding generation step that exists in the frontend-ci workflow, causing import errors for:
- `../../../wailsjs/go/pkg/App` in `apiUtils.js`
- `../../../wailsjs/go/pkg/App` in `syncUtils.js`

This fix aligns the update-readme-coverage workflow with the working frontend-ci workflow configuration.